### PR TITLE
Minor config/setup changes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,6 @@ requests==2.25.1
 requests-toolbelt==0.9.1
 rfc3986==1.4.0
 SecretStorage==3.3.1
-setuptools==56.1.0
 six==1.15.0
 soupsieve==2.2.1
 tqdm==4.60.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+long_description = file: README.md

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,20 @@
-from distutils.core import setup
+from pathlib import Path
+from setuptools import find_packages, setup
+
+def load_requirements():
+    return [
+        l.strip()
+        for l in Path('requirements.txt').read_text().splitlines()
+        if not l.startswith('#')
+    ]
 
 setup(
     name='tordl',
-    packages=['tordl'],
-    version='1.06',
+    packages=find_packages(where='tordl'),
+    package_dir={
+        '': 'tordl'
+    },
+    version='1.0.6',
     license='MIT',
     description='CLI Torrent Search and Download',
     author='x0r0x',
@@ -11,22 +22,7 @@ setup(
     url='https://github.com/X0R0X/cli-torrent-dl/',
     download_url='https://github.com/X0R0X/cli-torrent-dl/archive/refs/heads/master.zip',
     keywords=['torrent', 'search', 'download', 'cli', 'curses'],
-    install_requires=[
-        'aiohttp==3.7.4.post0',
-        'async-timeout==3.0.1',
-        'attrs==20.3.0',
-        'beautifulsoup4==4.9.3',
-        'bs4==0.0.1',
-        'chardet==4.0.0',
-        'idna==3.1',
-        'multidict==5.1.0',
-        'soupsieve==2.2.1',
-        'setuptools==56.1.0',
-        'typing-extensions==3.7.4.3',
-        'yarl==1.6.3',
-        'aiohttp==3.7.4.post0',
-        'beautifulsoup4',
-    ],
+    install_requires=load_requirements(),
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: End Users/Desktop',

--- a/setup_venv.sh
+++ b/setup_venv.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-VENV_DIR="$HOME/.torrent_dl/.venv"
+VENV_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/torrentdl/.venv"
 
 # get path of this script, resolving all symlinks.
 SOURCE="${BASH_SOURCE[0]}"

--- a/tordl.sh
+++ b/tordl.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-VENV_DIR="$HOME/.torrent_dl/.venv"
+VENV_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/torrentdl/.venv"
 [[ -d $VENV_DIR ]] || exit 1
 
 # get path of this script, resolving all symlinks.
@@ -14,5 +14,5 @@ done
 SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" > /dev/null 2>&1 && pwd)"
 
 . "$VENV_DIR/bin/activate"
-python3 "$SCRIPT_DIR/tordl.py" $@
+python3 "$SCRIPT_DIR/tordl.py" "$@"
 deactivate


### PR DESCRIPTION
Hey.

Got a few changes here, so I'll just make a small list:

- Remove setuptools from requirements. IIRC, it gets handled automatically.
- Use the newer recommended syntax for description files.
- distutils is deprecated, so switch to setuptools. This doesn't seem to break anything.
- `setup.py` changes the version number from 1.06 to 1.6; that seems undesirable. This doesn't happen if you make it 1.0.6.
- Load install requirements dynamically from `requirements.txt`. That way, you only have to keep track of one list.
- Move venv to proper XDG config directory. This should work if someone sets `$XDG_CONFIG_HOME`.
- Quote arguments in `tordl.sh` when passing them to python.

I'm also working on a bunch of other things, such as support for copying magnet links to the clipboard instead of opening them in a client, as well as some other major engines. I'll do PRs when I have the engines ready, but I don't want to flood you with random PRs otherwise. So, please feel free to take whatever you like from my repo's branches anytime. I don't care about getting credit or anything like that. I just do this for fun, and because I think this a great tool.